### PR TITLE
ci(release): migrate to pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: 📜 Coverage report
         if: ${{ steps.changes.outputs.app == 'true' && matrix.os == 'ubuntu-latest' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/cobertura-coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,3 @@ jobs:
   ci:
     uses: raven-actions/.workflows/.github/workflows/__ci-testcov.yml@main
     secrets: inherit
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,125 +13,17 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      debug:
-        type: choice
-        description: Debug mode
-        required: false
-        options:
-          - 'true'
-          - 'false'
 
-# Allow one concurrent
-concurrency:
-  group: ${{ format('{0}-{1}-{2}-{3}-{4}', github.workflow, github.event_name, github.ref, github.base_ref, github.head_ref) }}
-  cancel-in-progress: true
-
-env:
-  DEBUG: ${{ inputs.debug || secrets.ACTIONS_RUNNER_DEBUG || vars.ACTIONS_RUNNER_DEBUG || secrets.ACTIONS_STEP_DEBUG || vars.ACTIONS_STEP_DEBUG || false }}
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  checks: write
+  actions: write
+  id-token: write
 
 jobs:
-  build-test:
-    name: Build and Test
-    if: ${{ contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) || (github.event_name == 'pull_request' && !github.event.pull_request.draft) }}
-    permissions:
-      contents: read
-      issues: read
-      checks: write
-      pull-requests: write
-      actions: write
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: 🩺 Debug
-        if: ${{ env.DEBUG == 'true' }}
-        uses: raven-actions/debug@v1
-        with:
-          vars-context: ${{ toJson(vars) }}
-          secrets-context: ${{ toJson(secrets) }}
-          needs-context: ${{ toJson(needs) }}
-          inputs-context: ${{ toJson(inputs) }}
+  ci:
+    uses: raven-actions/.workflows/.github/workflows/__ci-testcov.yml@main
+    secrets: inherit
 
-      - name: ⤵️ Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: 🔄️ Detect changes
-        uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            app:
-              - 'src/**'
-              - 'tests/**'
-              - 'package.json'
-              - 'package-lock.json'
-              - '.node-version'
-              - 'jest.config.js'
-              - 'tsconfig.json'
-
-      - name: 🚧 Install pnpm
-        if: ${{ steps.changes.outputs.app == 'true' }}
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          run_install: false
-
-      - name: 🚧 Setup Node
-        if: ${{ steps.changes.outputs.app == 'true' }}
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .node-version
-          cache: pnpm
-
-      - name: 🔀 Install dependencies
-        if: ${{ steps.changes.outputs.app == 'true' }}
-        run: pnpm install --frozen-lockfile
-
-      - name: 🏗️ Build
-        if: ${{ steps.changes.outputs.app == 'true' }}
-        run: pnpm build:ci
-
-      - name: 🧪 Test
-        if: ${{ steps.changes.outputs.app == 'true' }}
-        run: pnpm test:ci:cov
-        continue-on-error: true
-
-      - name: 📤 Upload test results
-        if: ${{ steps.changes.outputs.app == 'true' && matrix.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: 'reports/jest-*.xml'
-          if-no-files-found: warn
-
-      - name: 📤 Upload coverage results
-        if: ${{ steps.changes.outputs.app == 'true' && matrix.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-results
-          path: coverage
-          if-no-files-found: warn
-
-      - name: 📜 Test report
-        if: ${{ steps.changes.outputs.app == 'true' && matrix.os == 'ubuntu-latest' }}
-        uses: phoenix-actions/test-reporting@v15
-        with:
-          name: 📜 Test report
-          path: 'reports/jest-*.xml'
-          reporter: jest-junit
-
-      - name: 📜 Coverage report
-        if: ${{ steps.changes.outputs.app == 'true' && matrix.os == 'ubuntu-latest' }}
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage/cobertura-coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: 📤 Upload test results
         if: ${{ steps.changes.outputs.app == 'true' && matrix.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: 'reports/jest-*.xml'
@@ -115,7 +115,7 @@ jobs:
 
       - name: 📤 Upload coverage results
         if: ${{ steps.changes.outputs.app == 'true' && matrix.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-results
           path: coverage

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -50,7 +50,7 @@ jobs:
           token: ${{ steps.get-token.outputs.token }}
 
       - name: 🚧 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
         with:
           version: 9
           run_install: false
@@ -62,7 +62,7 @@ jobs:
           cache: pnpm
 
       - name: 🔀 Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm deps:ci
 
       - name: 🏗️ Build
         run: pnpm build:ci

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: 🩺 Debug
         if: ${{ env.DEBUG == 'true' }}
-        uses: raven-actions/debug@v1
+        uses: raven-actions/debug@13e7c5b2e0436a1b85276087eba43ec7d46bd955 # v1.1.0
         with:
           vars-context: ${{ toJson(vars) }}
           secrets-context: ${{ toJson(secrets) }}
@@ -38,40 +38,45 @@ jobs:
           inputs-context: ${{ toJson(inputs) }}
 
       - name: 🔑 Get Token
-        uses: wow-actions/use-app-token@v2
+        uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1.11.1
         id: get-token
         with:
-          app_id: ${{ secrets.ORG_BOT_APP_ID }}
-          private_key: ${{ secrets.ORG_BOT_PRIVATE_KEY }}
-          fallback: ${{ github.token }}
+          app-id: ${{ secrets.ORG_BOT_APP_ID }}
+          private-key: ${{ secrets.ORG_BOT_PRIVATE_KEY }}
 
       - name: ⤵️ Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ steps.get-token.outputs.BOT_TOKEN }}
+          token: ${{ steps.get-token.outputs.token }}
+
+      - name: 🚧 Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
 
       - name: 🚧 Setup Node
         uses: actions/setup-node@v4
         with:
           node-version-file: .node-version
-          cache: npm
+          cache: pnpm
 
       - name: 🔀 Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: 🏗️ Build
-        run: npm run build:ci
+        run: pnpm build:ci
 
       - name: 🤖 Get bot details
         id: bot-details
         uses: raven-actions/bot-details@v1
         with:
-          bot-slug-name: ${{ steps.get-token.outputs.BOT_NAME }}
+          bot-slug-name: ${{ steps.get-token.outputs.app-slug }}
 
       - name: 🚀 Publish and Tag Action
         uses: ./
         with:
-          github_token: ${{ steps.get-token.outputs.BOT_TOKEN }}
+          github_token: ${{ steps.get-token.outputs.token }}
           tag_name: ${{ env.TAG_NAME }}
           rewrite_tags: true
           latest: true

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "run:dev": "pnpm dlx @vercel/ncc run ./src/index.ts",
     "run": "node dist/index.js",
     "deps:ck": "pnpm outdated --long",
-    "deps": "pnpm update --latest"
+    "deps:up": "pnpm update --latest",
+    "deps:ci": "pnpm install --frozen-lockfile"
   },
   "dependencies": {
     "@actions/core": "^1.11.1",


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/release-publish.yml` file to improve the workflow configuration. The most important changes include updating action versions, modifying parameters for consistency, and switching from npm to pnpm for package management.