### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -25,8 +25,8 @@ jobs:
   build-publish-tag:
     name: Build, Publish and Tag
     runs-on: ubuntu-latest
-    # permissions:
-    #   contents: write
+    permissions:
+      contents: write
     steps:
       - name: 🩺 Debug
         if: ${{ env.DEBUG == 'true' }}


### PR DESCRIPTION
Potential fix for [https://github.com/raven-actions/publish-and-tag/security/code-scanning/5](https://github.com/raven-actions/publish-and-tag/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow (e.g., publishing and tagging releases), the `contents: write` permission is likely required. Adding this block ensures that the workflow adheres to the principle of least privilege.

The `permissions` block can be added either at the root level of the workflow (to apply to all jobs) or within the specific job (`build-publish-tag`). Since the flagged issue pertains to the `build-publish-tag` job, we will add the `permissions` block within this job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
